### PR TITLE
clear_and-type function: update Ctrl+A to click 3 times

### DIFF
--- a/actions/keyboard.js
+++ b/actions/keyboard.js
@@ -4,8 +4,7 @@ const type = ({ selector, text }) => driver.type(selector, text)
 
 const clearAndType = async ({ selector, text }) => {
   await driver.focus(selector)
-  await driver.keydown('Control')
-  await driver.keypress('A')
+  await driver.click(selector, { clickCount: 3 })
   await driver.keyup('Control')
   await driver.keypress('Backspace')
   return driver.type(selector, text)


### PR DESCRIPTION
Ctr+A does not work for mac, so use click 3 times